### PR TITLE
Hotfix: LoginDTO 수정 및 로그인 시 refresh token 설정

### DIFF
--- a/src/main/java/fingertips/backend/member/mapper/MemberMapper.java
+++ b/src/main/java/fingertips/backend/member/mapper/MemberMapper.java
@@ -9,4 +9,5 @@ public interface MemberMapper {
     MemberDTO getMember(String username);
     void insertMember(MemberDTO memberDTO);
     void deleteMember(String username);
+    void setRefreshToken(MemberDTO memberDTO);
 }

--- a/src/main/java/fingertips/backend/member/service/MemberService.java
+++ b/src/main/java/fingertips/backend/member/service/MemberService.java
@@ -7,7 +7,8 @@ public interface MemberService {
 
     String authenticate(String username, String password);
     void joinMember(MemberDTO memberDTO);
-    LoginDTO getMemberByUsername(String username);
+    MemberDTO getMemberByUsername(String username);
     void deleteMember(String username);
     boolean validateMember(String username, String password);
+    void setRefreshToken(MemberDTO memberDTO);
 }

--- a/src/main/java/fingertips/backend/member/service/MemberServiceImpl.java
+++ b/src/main/java/fingertips/backend/member/service/MemberServiceImpl.java
@@ -34,16 +34,9 @@ public class MemberServiceImpl implements MemberService {
         mapper.insertMember(memberDTO);
     }
 
-    public LoginDTO getMemberByUsername(String username) {
-        MemberDTO memberDTO = mapper.getMember(username);
-        if (memberDTO != null) {
-            return LoginDTO.builder()
-                    .memberId(memberDTO.getMemberId())
-                    .password(memberDTO.getPassword())
-                    .accessToken(jwtProcessor.generateAccessToken(memberDTO.getMemberId(), memberDTO.getRole()))
-                    .build();
-        }
-        return null;
+    public MemberDTO getMemberByUsername(String username) {
+
+        return mapper.getMember(username);
     }
 
     public void deleteMember(String username) {
@@ -51,12 +44,18 @@ public class MemberServiceImpl implements MemberService {
     }
 
     public boolean validateMember(String username, String password) {
-        LoginDTO loginDTO = getMemberByUsername(username);
+        MemberDTO memberDTO = getMemberByUsername(username);
 
-        if (loginDTO != null) {
-            return passwordEncoder.matches(password, loginDTO.getPassword());
+        if (memberDTO != null) {
+            return passwordEncoder.matches(password, memberDTO.getPassword());
         }
 
         return false;
+    }
+
+    @Override
+    public void setRefreshToken(MemberDTO memberDTO) {
+
+        mapper.setRefreshToken(memberDTO);
     }
 }

--- a/src/main/java/fingertips/backend/security/account/dto/LoginDTO.java
+++ b/src/main/java/fingertips/backend/security/account/dto/LoginDTO.java
@@ -20,7 +20,6 @@ public class LoginDTO {
     private String password;
     private String accessToken;
     private String refreshToken;
-    private String role;
 
     public static LoginDTO of(HttpServletRequest request) throws AuthenticationException {
         ObjectMapper om = new ObjectMapper();

--- a/src/main/resources/mapper/MemberMapper.xml
+++ b/src/main/resources/mapper/MemberMapper.xml
@@ -9,7 +9,11 @@
     </select>
 
     <insert id="insertMember" parameterType="MemberDTO">
-        INSERT INTO member (member_id, password, birthday, gender, email, role)
-        VALUES (#{memberId}, #{password}, #{birthday}, #{gender}, #{email}, #{role})
+        INSERT INTO member (member_id, password, birthday, gender, email)
+        VALUES (#{memberId}, #{password}, #{birthday}, #{gender}, #{email})
     </insert>
+
+    <update id="setRefreshToken" parameterType="MemberDTO">
+        UPDATE member SET refresh_token = #{refreshToken} WHERE id = #{id}
+    </update>
 </mapper>


### PR DESCRIPTION
### #️⃣연관된 이슈
- SCRUM121

### 📝작업 내용
- 로그인 시 member table의 refresh token 설정
- LoginDTO에서 role 제거하고 LoginDTO의 memberId가 admin으로 시작하는 경우 AuthDTO의 role을 ROLE_ADMIN으로 설정, 그렇지 않은 경우 일반 사용자로 판단하고 ROLE_USER로 설정
  - 로그인 시 아이디를 admin으로 시작하지 못하게 예외처리 해야 함

### 💬리뷰 요구사항(선택)
- 회원가입, 로그인 진행 후 받은 access token 잘 적용되는 지 확인 부탁드립니다 !
