### PR TITLE
Hotfix: 회원 탈퇴 처리 로직 구현 및 DB 변수에 맞게 코드 수정

### DIFF
--- a/src/main/java/fingertips/backend/member/dto/MemberDTO.java
+++ b/src/main/java/fingertips/backend/member/dto/MemberDTO.java
@@ -14,6 +14,7 @@ public class MemberDTO {
     private String memberId;
     private String password;
     private String memberName;
+    private String socialType;
     private String birthday;
     private String gender;
     private String email;
@@ -21,12 +22,10 @@ public class MemberDTO {
     private String joinDate;
     private String region;
     private String job;
-    private Integer testStatus;
-    private Integer activeStatus;
-    private String socialType;
+    private Integer isActive;
     private String refreshToken;
     private String withdrawDate;
     private String role;
-    private Integer loginLocked;
+    private Integer isLoginLocked;
     private Long loginLockTime;
 }

--- a/src/main/java/fingertips/backend/member/mapper/MemberMapper.java
+++ b/src/main/java/fingertips/backend/member/mapper/MemberMapper.java
@@ -15,4 +15,5 @@ public interface MemberMapper {
     String findByNameAndEmail(MemberIdFindDTO memberIdFindDTO);
     int existsMemberId(String memberId);
     void clearRefreshToken(String memberId);
+    void withdrawMember(String memberId);
 }

--- a/src/main/java/fingertips/backend/member/service/MemberService.java
+++ b/src/main/java/fingertips/backend/member/service/MemberService.java
@@ -9,9 +9,9 @@ public interface MemberService {
     String authenticate(String username, String password);
     void joinMember(MemberDTO memberDTO);
     MemberDTO getMemberByMemberId(String memberId);
-    void deleteMember(String username);
     void setRefreshToken(MemberDTO memberDTO);
     boolean existsMemberId(String memberId);
     void clearRefreshToken(String memberId);
     String findByNameAndEmail(String memberName, String email);
+    void withdrawMember(String memberId);
 }

--- a/src/main/java/fingertips/backend/member/service/MemberServiceImpl.java
+++ b/src/main/java/fingertips/backend/member/service/MemberServiceImpl.java
@@ -50,10 +50,6 @@ public class MemberServiceImpl implements MemberService {
         return member;
     }
 
-    public void deleteMember(String username) {
-        memberMapper.deleteMember(username);
-    }
-
     @Override
     public void setRefreshToken(MemberDTO memberDTO) {
 
@@ -90,5 +86,9 @@ public class MemberServiceImpl implements MemberService {
             log.error("Error occurred while finding member by name and email: ", e);
             throw new ApplicationException(ApplicationError.INTERNAL_SERVER_ERROR);
         }
+    }
+
+    public void withdrawMember(String memberId) {
+        memberMapper.withdrawMember(memberId);
     }
 }

--- a/src/main/java/fingertips/backend/security/handle/LoginFailureHandler.java
+++ b/src/main/java/fingertips/backend/security/handle/LoginFailureHandler.java
@@ -57,14 +57,14 @@ public class LoginFailureHandler implements AuthenticationFailureHandler {
 
         long currentTime = System.currentTimeMillis();
 
-        if (memberDTO.getLoginLocked() == 1) {
+        if (memberDTO.getIsLoginLocked() == 1) {
             if (currentTime < memberDTO.getLoginLockTime() + LOCK_TIME_DURATION) {
                 log.info("currentTime: " + currentTime);
                 log.info("memberDTO.getLoginLockTime() + LOCK_TIME_DURATION: " + (memberDTO.getLoginLockTime() + LOCK_TIME_DURATION));
                 JsonResponse.sendError(response, ApplicationError.LOGIN_ATTEMPTS);
                 return;
             } else {
-                memberDTO.setLoginLocked(0);
+                memberDTO.setIsLoginLocked(0);
                 memberDTO.setLoginLockTime(0L);
                 memberMapper.updateLockStatus(memberDTO);
                 attemptsCache.put(memberId, 0);
@@ -76,7 +76,7 @@ public class LoginFailureHandler implements AuthenticationFailureHandler {
         log.info("attempts: " + attempts);
 
         if (attempts >= MAX_ATTEMPTS) {
-            memberDTO.setLoginLocked(1);
+            memberDTO.setIsLoginLocked(1);
             memberDTO.setLoginLockTime(currentTime);
             log.info("currentTime: " + currentTime);
             memberMapper.updateLockStatus(memberDTO);

--- a/src/main/java/fingertips/backend/security/handle/LoginSuccessHandler.java
+++ b/src/main/java/fingertips/backend/security/handle/LoginSuccessHandler.java
@@ -63,7 +63,7 @@ public class LoginSuccessHandler implements AuthenticationSuccessHandler {
         JsonResponse.sendToken(response, result);
         loginFailureHandler.getAttemptsCache().put(memberId, 0);
 
-        memberDTO.setLoginLocked(0);
+        memberDTO.setIsLoginLocked(0);
         memberDTO.setLoginLockTime(0L);
         memberMapper.updateLockStatus(memberDTO);
     }

--- a/src/main/java/fingertips/backend/security/service/CustomUserDetailsService.java
+++ b/src/main/java/fingertips/backend/security/service/CustomUserDetailsService.java
@@ -21,15 +21,15 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        MemberDTO dto = mapper.getMemberByMemberId(username);
-        if (dto == null) {
+        MemberDTO memberDTO = mapper.getMemberByMemberId(username);
+        if (memberDTO == null) {
             throw new UsernameNotFoundException("존재하지 않는 아이디입니다.");
         }
 
         return new User(
-                dto.getMemberId(),
-                dto.getPassword(),
-                Collections.singletonList(new SimpleGrantedAuthority(dto.getRole()))
+                memberDTO.getMemberId(),
+                memberDTO.getPassword(),
+                Collections.singletonList(new SimpleGrantedAuthority(memberDTO.getRole()))
         );
     }
 }

--- a/src/main/resources/mapper/ChallengeMapper.xml
+++ b/src/main/resources/mapper/ChallengeMapper.xml
@@ -17,7 +17,7 @@
 
     <delete id="deleteChallenge" parameterType="Integer">
         UPDATE challenge
-        SET active_status = 1
+        SET is_active = 1
         WHERE id = #{challengeId}
     </delete>
 

--- a/src/main/resources/mapper/MemberMapper.xml
+++ b/src/main/resources/mapper/MemberMapper.xml
@@ -17,14 +17,14 @@
 
     <update id="updateLockStatus" parameterType="MemberDTO">
         UPDATE member
-        SET login_locked = #{loginLocked}, login_lock_time = #{loginLockTime}
+        SET is_login_locked = #{isLoginLocked}, login_lock_time = #{loginLockTime}
         WHERE member_id = #{memberId}
     </update>
 
     <update id="setRefreshToken" parameterType="MemberDTO">
         UPDATE member
         SET refresh_token = #{refreshToken}
-        WHERE id = #{id}
+        WHERE member_idx = #{memberIdx}
     </update>
 
     <select id="findByNameAndEmail" parameterType="MemberIdFindDTO" resultType="String">
@@ -41,8 +41,15 @@
     </select>
 
     <update id="clearRefreshToken">
-        UPDATE member_table
+        UPDATE member
         SET refresh_token = NULL
         WHERE member_id = #{memberId}
     </update>
+
+    <update id="withdrawMember" parameterType="String">
+        UPDATE member
+        SET is_active = 0, withdraw_date = NOW()
+        WHERE member_id = #{memberId}
+    </update>
+
 </mapper>


### PR DESCRIPTION
#️⃣연관된 이슈
[SCRUM-278]

📝작업 내용
1. 회원 탈퇴 처리 로직 구현
- 회원이 탈퇴할 경우 데이터를 삭제하지 않고, 회원 상태를 '탈퇴'로 변경하는 로직 추가
- `withdrawMember(String memberId)` 메서드 추가하여 회원 탈퇴 시 `is_active`를 0으로 변경하고, `withdraw_date`에 탈퇴 날짜를 기록
  - DTO (`MemberDTO`): `withdrawDate` 필드 추가
  - Service: `withdrawMember` 메서드 추가
  - ServiceImpl: `withdrawMember` 메서드에서 `memberMapper.withdrawMember(memberId)` 호출
  - Mapper: `withdrawMember` SQL 쿼리 추가, `is_active`를 0으로, `withdraw_date`에 `NOW()` 값을 기록

2. DB 변수에 맞게 코드 수정
- 테이블 `member`의 컬럼에 맞추어 DTO, Mapper, Service 수정
  - `is_active`, `withdraw_date` 필드 추가 및 수정
  - 기존 `deleteMember` 메서드를 사용하지 않고, 탈퇴 회원 상태로 처리하는 `withdrawMember` 메서드로 변경
  - MyBatis Mapper에서 `member_id`를 기반으로 `withdraw_date`와 `is_active` 필드 업데이트 쿼리 적용
  - 회원 정보는 DB에서 삭제되지 않고 탈퇴 상태로만 변경되며, 이후에도 해당 회원의 정보를 유지

3. 기타 수정 사항
- `member_id`와 관련된 필드명 수정 및 코드 정리
- 필요에 따라 로그를 추가하여 회원 탈퇴 처리 과정 확인


[SCRUM-278]: https://fingertips-mz.atlassian.net/browse/SCRUM-278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ