### PR TITLE
Hotfix: 구글 회원가입 시 memberIdx return하도록 수정

### DIFF
--- a/src/main/java/fingertips/backend/member/sociallogin/dto/SocialLoginDTO.java
+++ b/src/main/java/fingertips/backend/member/sociallogin/dto/SocialLoginDTO.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 public class SocialLoginDTO {
     private String memberIdx;
     private String memberId;
+    private String password;
     private String email;
     private String memberName;
     private String googleId;

--- a/src/main/resources/mapper/SocialLoginMapper.xml
+++ b/src/main/resources/mapper/SocialLoginMapper.xml
@@ -12,8 +12,8 @@
     </select>
 
     <insert id="insertMember" parameterType="SocialLoginDTO">
-        INSERT INTO member (member_id, email, member_name, google_id, social_type, google_access_token, google_id_token, google_refresh_token, expires_in)
-        VALUES (#{memberId}, #{email}, #{memberName}, #{googleId}, #{socialType}, #{googleAccessToken}, #{googleIdToken}, #{googleRefreshToken}, #{expiresIn})
+        INSERT INTO member (member_id, password, email, member_name, google_id, social_type, google_access_token, google_id_token, google_refresh_token, expires_in)
+        VALUES (#{memberId}, #{password}, #{email}, #{memberName}, #{googleId}, #{socialType}, #{googleAccessToken}, #{googleIdToken}, #{googleRefreshToken}, #{expiresIn})
     </insert>
 
     <update id="updateMemberTokens" parameterType="SocialLoginDTO">


### PR DESCRIPTION
### #️⃣연관된 이슈
- [SCRUM-140]

### 📝작업 내용
- 구글 소셜 사용자에 대해 token 생성 시 랜덤 생성된 member id를 바탕으로 token 생성
- 구글 소셜 로그인 시 랜덤 password 생성하여 저장
- 구글 소셜 로그인 시 DB에 insert 후 mapper를 통해 해당 회원의 memberIdx를 받아온 후 return할 memberInfo에 setMemberIdx 적용하여 최초 구글 소셜 로그인 사용자에 대한 memberIdx 반환



[SCRUM-140]: https://fingertips-mz.atlassian.net/browse/SCRUM-140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ