### PR TITLE
Hotfix: log4j 버전 업그레이드

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,8 +59,8 @@ dependencies {
 
   // log4jdbc-log4j2
   implementation 'org.bgee.log4jdbc-log4j2:log4jdbc-log4j2-jdbc4:1.16'
-  implementation 'org.apache.logging.log4j:log4j-api:2.0.1'
-  implementation 'org.apache.logging.log4j:log4j-core:2.0.1'
+  implementation 'org.apache.logging.log4j:log4j-api:2.17.1'
+  implementation 'org.apache.logging.log4j:log4j-core:2.17.1'
 
   // xml 내 한글 처리
   implementation 'xerces:xercesImpl:2.12.2'


### PR DESCRIPTION
### #️⃣연관된 이슈
[SCRUM-322]

### 📝작업 내용
맥북에서 log4j 파일에서 호환했을 경우, 버전 호환이 안 되는 오류가 생겨 버전 업그레이드를 진행하였습니다.
윈도우에서도 잘 작동되는 지 확인 후 PR 올립니다.


[SCRUM-322]: https://fingertips-mz.atlassian.net/browse/SCRUM-322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ