### PR TITLE
Feat: 탈퇴 로직 API 구현 완료

### DIFF
--- a/src/main/java/fingertips/backend/member/controller/MemberController.java
+++ b/src/main/java/fingertips/backend/member/controller/MemberController.java
@@ -214,4 +214,12 @@ public class MemberController {
         memberService.changeEmail(memberId, newEmail);
         return ResponseEntity.ok(JsonResponse.success("Email changed successfully"));
     }
+
+    @PostMapping("/withdraw")
+    public ResponseEntity<JsonResponse<String>> withdrawMember(@RequestBody Integer memberIdx) {
+
+        log.info("withdraw memberIdx:" + memberIdx.toString());
+        memberService.withdrawMember(memberIdx);
+        return ResponseEntity.ok().body(JsonResponse.success("Withdraw successfully"));
+    }
 }

--- a/src/main/java/fingertips/backend/member/mapper/MemberMapper.java
+++ b/src/main/java/fingertips/backend/member/mapper/MemberMapper.java
@@ -17,12 +17,12 @@ public interface MemberMapper {
     ProfileDTO getProfile(String memberId);
     String getPassword(String memberId);
     void clearRefreshToken(String memberId);
-    void withdrawMember(String memberId);
+    void withdrawMember(Integer memberIdx);
 
     void updatePasswordByEmail(PasswordFindDTO passwordFindDTO);
     int checkEmailDuplicate(String email);
     int existsMemberName(String memberName);
-		void saveNewPassword(NewPasswordDTO newPassword);
+    void saveNewPassword(NewPasswordDTO newPassword);
     void saveNewImage(UploadFileDTO uploadFile);
     void saveNewEmail(NewEmailDTO newEmail);
 

--- a/src/main/java/fingertips/backend/member/service/MemberService.java
+++ b/src/main/java/fingertips/backend/member/service/MemberService.java
@@ -22,10 +22,8 @@ public interface MemberService {
 
     void clearRefreshToken(String memberId);
     String findByNameAndEmail(String memberName, String email);
-    void withdrawMember(String memberId);
+    void withdrawMember(Integer memberIdx);
     void updatePasswordByEmail(PasswordFindDTO passwordFindDTO);
     PasswordFindDTO processFindPassword(String memberName, String email);
     String processVerifyPassword(PasswordFindDTO passwordFindDTO);
-
-
 }

--- a/src/main/java/fingertips/backend/member/service/MemberServiceImpl.java
+++ b/src/main/java/fingertips/backend/member/service/MemberServiceImpl.java
@@ -102,9 +102,10 @@ public class MemberServiceImpl implements MemberService {
     }
     
     @Override
-    public void withdrawMember(String memberId) {
+    public void withdrawMember(Integer memberIdx) {
 
-        memberMapper.withdrawMember(memberId);
+        log.info("withdrawMember Service 진입");
+        memberMapper.withdrawMember(memberIdx);
     }
 
     @Override

--- a/src/main/java/fingertips/backend/security/config/SecurityConfig.java
+++ b/src/main/java/fingertips/backend/security/config/SecurityConfig.java
@@ -122,6 +122,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers(HttpMethod.GET, "/api/v1/member/login/google/**").permitAll()
                 .antMatchers(HttpMethod.POST, "/api/v1/member/logout").authenticated()
                 .antMatchers(HttpMethod.POST, "/api/v1/member/refresh").authenticated()
+                .antMatchers(HttpMethod.POST, "/api/v1/member/withdraw").authenticated()
                 .antMatchers("/api/v1/asset/**").authenticated()
                 .antMatchers("/api/v1/challenge/**").authenticated()
                 .antMatchers("/api/v1/consumption/**").authenticated()

--- a/src/main/resources/mapper/MemberMapper.xml
+++ b/src/main/resources/mapper/MemberMapper.xml
@@ -7,7 +7,7 @@
     <select id="getMemberByMemberId" parameterType="String" resultType="MemberDTO">
         SELECT *
         FROM member
-        WHERE member_id = #{memberId}
+        WHERE member_id = #{memberId} AND is_active = 1
     </select>
 
     <insert id="insertMember" parameterType="MemberDTO">
@@ -78,10 +78,10 @@
         WHERE member_id = #{memberId}
     </update>
 
-    <update id="withdrawMember" parameterType="String">
+    <update id="withdrawMember" parameterType="Integer">
         UPDATE member
         SET is_active = 0, withdraw_date = NOW()
-        WHERE member_id = #{memberId}
+        WHERE member_idx = #{memberIdx}
     </update>
 
     <update id="updatePasswordByEmail" parameterType="PasswordFindDTO">


### PR DESCRIPTION
### #️⃣연관된 이슈
- [SCRUM-326]

### 📝작업 내용
- 사용자 인증 확인 시 is_active가 1인 사용자만 불러오도록 mapper 수정
- 회원 탈퇴 컨트롤러 생성
- 기존 탈퇴 로직 service, mapper code의 String memberId -> Integer memberIdx 로 수정

[SCRUM-326]: https://fingertips-mz.atlassian.net/browse/SCRUM-326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ